### PR TITLE
Fixed hour hand offset according to minute hand.

### DIFF
--- a/Clock/Classes/SAMClockView.m
+++ b/Clock/Classes/SAMClockView.m
@@ -220,8 +220,8 @@ NSString *const SAMClockLogoDefaultsKey = @"SAMClockLogo";
 	}
 
 	CGFloat seconds = (CGFloat)comps.second / 60.0f;
-	CGFloat minutes = (seconds / 60.0f) + ((CGFloat)comps.minute / 60.0f);
-	CGFloat hours = (minutes / 60.0f) + ((CGFloat)comps.hour / 12.0f);
+	CGFloat minutes = ((CGFloat)comps.minute / 60.0f) + (seconds / 60.0f);
+	CGFloat hours = ((CGFloat)comps.hour / 12.0f) + ((minutes / 60.0f) * (60.0f / 12.0f));
 
 	// Hours
 	[[handColor colorWithAlphaComponent:0.7f] setStroke];


### PR DESCRIPTION
Noticed that the hours hand was not reflecting the minutes hand progression. Should be fixed now.

Before:
![clock-saver-before](https://f.cloud.github.com/assets/1283783/2490657/cbd9f09a-b1ba-11e3-8876-89f7fdd8af47.png)

After:
![clock-saver-after](https://f.cloud.github.com/assets/1283783/2490658/d19e14e8-b1ba-11e3-9386-21f86fb8d0f7.png)
